### PR TITLE
Cleanup system config caching

### DIFF
--- a/pm_control/include/pm_control/PMControl.h
+++ b/pm_control/include/pm_control/PMControl.h
@@ -2,67 +2,64 @@
 
 #include "pm_widget/ControlledRobot.h"
 
-#include <ui_PMControl.h>
-#include <process_manager/ProcessStats.h>
-#include <process_manager/ProcessStat.h>
-#include <essentials/AgentID.h>
 #include <SystemConfig.h>
+#include <essentials/AgentID.h>
+#include <process_manager/ProcessStat.h>
+#include <process_manager/ProcessStats.h>
+#include <ui_PMControl.h>
 
-#include <QtGui>
-#include <QWidget>
 #include <QDialog>
-#include <rqt_gui_cpp/plugin.h>
-#include <ros/ros.h>
+#include <QWidget>
+#include <QtGui>
 #include <ros/macros.h>
+#include <ros/ros.h>
+#include <rqt_gui_cpp/plugin.h>
 
-#include <queue>
-#include <mutex>
-#include <utility>
 #include <chrono>
+#include <mutex>
+#include <queue>
+#include <utility>
 
-namespace  essentials {
+namespace essentials
+{
 class RobotExecutableRegistry;
-}  // namespace  essentials
+} // namespace  essentials
 
-namespace pm_widget {
+namespace pm_widget
+{
 class ControlledProcessManager;
 }
 
-namespace pm_control {
-class PMControl : public rqt_gui_cpp::Plugin {
+namespace pm_control
+{
+class PMControl : public rqt_gui_cpp::Plugin
+{
     Q_OBJECT
 
-public:
+  public:
     PMControl();
     virtual void initPlugin(qt_gui_cpp::PluginContext& context);
     virtual void shutdownPlugin();
     virtual void saveSettings(qt_gui_cpp::Settings& plugin_settings, qt_gui_cpp::Settings& instance_settings) const;
-    virtual void restoreSettings(
-            const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
+    virtual void restoreSettings(const qt_gui_cpp::Settings& plugin_settings, const qt_gui_cpp::Settings& instance_settings);
 
-    void sendProcessCommand(const essentials::AgentID* receiverId,
-            std::vector<const essentials::AgentID*> robotIds, std::vector<int> execIds, std::vector<int> paramSets,
-            int cmd);
+    void sendProcessCommand(const essentials::AgentID* receiverId, std::vector<const essentials::AgentID*> robotIds, std::vector<int> execIds,
+                            std::vector<int> paramSets, int cmd);
 
     std::chrono::duration<double> msgTimeOut;
 
     Ui::PMControlWidget ui_;
     QWidget* widget_;
 
-     essentials::RobotExecutableRegistry* pmRegistry;
+    essentials::RobotExecutableRegistry* pmRegistry;
 
-private:
+  private:
     ros::NodeHandle* rosNode;
     ros::Subscriber processStateSub;
     ros::Publisher processCommandPub;
-    std::queue<std::pair<std::chrono::system_clock::time_point, process_manager::ProcessStatsConstPtr>>
-            processStatMsgQueue;
+    std::queue<std::pair<std::chrono::system_clock::time_point, process_manager::ProcessStatsConstPtr>> processStatMsgQueue;
     std::mutex msgQueueMutex;
-
-    essentials::SystemConfig* sc;
-
-    std::map<const essentials::AgentID*, pm_widget::ControlledProcessManager*, essentials::AgentIDComparator>
-            processManagersMap;
+    std::map<const essentials::AgentID*, pm_widget::ControlledProcessManager*, essentials::AgentIDComparator> processManagersMap;
 
     void handleProcessStats();
 
@@ -71,9 +68,9 @@ private:
 
     QTimer* guiUpdateTimer;
 
-public Q_SLOTS:
+  public Q_SLOTS:
     void run();
     void updateGUI();
 };
 
-}  // namespace pm_control
+} // namespace pm_control

--- a/pm_control/src/pm_control/PMControl.cpp
+++ b/pm_control/src/pm_control/PMControl.cpp
@@ -19,25 +19,25 @@ PMControl::PMControl()
     setObjectName("PMControl");
     rosNode = new ros::NodeHandle();
 
-    this->sc = essentials::SystemConfig::getInstance();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
 
-    this->msgTimeOut = chrono::duration<double>((*this->sc)["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
+    this->msgTimeOut = chrono::duration<double>(sc["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
 
-    this->pmRegistry =  essentials::RobotExecutableRegistry::get();
+    this->pmRegistry = essentials::RobotExecutableRegistry::get();
 
     /* Initialise the registry data structure for better performance
      * with data from Globals.conf and ProcessManaging.conf file. */
 
     // Register robots from Globals.conf
     const essentials::AgentID* tmpAgentID;
-    auto robotNames = (*this->sc)["Globals"]->getSections("Globals.Team", NULL);
+    auto robotNames = sc["Globals"]->getSections("Globals.Team", NULL);
     for (auto robotName : (*robotNames)) {
         tmpAgentID = this->pmRegistry->addRobot(robotName);
     }
 
     // Register executables from ProcessManaging.conf
     int tmpExecID;
-    auto processDescriptions = (*this->sc)["ProcessManaging"]->getSections("Processes.ProcessDescriptions", NULL);
+    auto processDescriptions = sc["ProcessManaging"]->getSections("Processes.ProcessDescriptions", NULL);
     for (auto processSectionName : (*processDescriptions)) {
         tmpExecID = this->pmRegistry->addExecutable(processSectionName);
     }
@@ -55,7 +55,8 @@ void PMControl::initPlugin(qt_gui_cpp::PluginContext& context)
     context.addWidget(widget_);
 
     // Initialise the ROS Communication
-    string statTopic = (*this->sc)["ProcessManaging"]->get<string>("Topics.processStatsTopic", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    string statTopic = sc["ProcessManaging"]->get<string>("Topics.processStatsTopic", NULL);
     processStateSub = rosNode->subscribe(statTopic, 10, &PMControl::receiveProcessStats, (PMControl*)this);
 
     // Initialise the GUI refresh timer

--- a/pm_control/src/pm_widget/ControlledExecutable.cpp
+++ b/pm_control/src/pm_widget/ControlledExecutable.cpp
@@ -25,7 +25,7 @@ const string ControlledExecutable::redBackground = "background-color:#FF4719;";
 const string ControlledExecutable::greenBackground = "background-color:#66FF66;";
 const string ControlledExecutable::grayBackground = "background-color:gray;";
 
-ControlledExecutable::ControlledExecutable( essentials::ExecutableMetaData* metaExec, ControlledRobot* parentRobot)
+ControlledExecutable::ControlledExecutable(essentials::ExecutableMetaData* metaExec, ControlledRobot* parentRobot)
     : metaExec(metaExec)
     , memory(0)
     , state('U')
@@ -33,7 +33,7 @@ ControlledExecutable::ControlledExecutable( essentials::ExecutableMetaData* meta
     , _processWidget(new Ui::ProcessWidget())
     , processWidget(new QWidget())
     , parentRobot(parentRobot)
-    , runningParamSet( essentials::ExecutableMetaData::UNKNOWN_PARAMS)
+    , runningParamSet(essentials::ExecutableMetaData::UNKNOWN_PARAMS)
     , desiredParamSet(INT_MAX)
     , publishing(false)
 {
@@ -54,10 +54,10 @@ ControlledExecutable::ControlledExecutable( essentials::ExecutableMetaData* meta
     this->processWidget->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
     connect(this->processWidget, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)));
 
-    this->msgTimeOut = chrono::duration<double>(
-        (*essentials::SystemConfig::getInstance())["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    this->msgTimeOut = chrono::duration<double>(sc["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
 
-    this->pmRegistry =  essentials::RobotExecutableRegistry::get();
+    this->pmRegistry = essentials::RobotExecutableRegistry::get();
 
     this->parentRobot->addExec(processWidget);
     this->processWidget->show();
@@ -132,7 +132,7 @@ void ControlledExecutable::updateGUI(chrono::system_clock::time_point now)
         this->_processWidget->processName->setText(QString(this->metaExec->name.c_str()));
         this->_processWidget->cpuState->setText(QString("C: -- %"));
         this->_processWidget->memState->setText(QString("M: -- MB"));
-        this->runningParamSet =  essentials::ExecutableMetaData::UNKNOWN_PARAMS;
+        this->runningParamSet = essentials::ExecutableMetaData::UNKNOWN_PARAMS;
         this->processWidget->setToolTip(QString(""));
         this->processWidget->setStyleSheet(redBackground.c_str());
     } else { // message arrived before timeout, update its GUI
@@ -157,7 +157,7 @@ void ControlledExecutable::updateGUI(chrono::system_clock::time_point now)
         case 'T': // traced, or stopped
             this->processWidget->setStyleSheet(redBackground.c_str());
             this->processWidget->setToolTip(QString(""));
-            this->runningParamSet =  essentials::ExecutableMetaData::UNKNOWN_PARAMS;
+            this->runningParamSet = essentials::ExecutableMetaData::UNKNOWN_PARAMS;
             break;
         case 'U':
         default:
@@ -212,7 +212,7 @@ void ControlledExecutable::handleBundleComboBoxChanged(QString bundle)
             if (this->metaExec->id == processParamSetPair.first) {
                 found = true;
                 this->desiredParamSet = processParamSetPair.second;
-                if (processParamSetPair.second == this->runningParamSet || this->runningParamSet ==  essentials::ExecutableMetaData::UNKNOWN_PARAMS) {
+                if (processParamSetPair.second == this->runningParamSet || this->runningParamSet == essentials::ExecutableMetaData::UNKNOWN_PARAMS) {
                     if (this->metaExec->name != "roscore") {
                         this->_processWidget->checkBox->setEnabled(true);
                     }

--- a/pm_control/src/pm_widget/ControlledProcessManager.cpp
+++ b/pm_control/src/pm_widget/ControlledProcessManager.cpp
@@ -15,11 +15,11 @@ namespace pm_widget
 ControlledProcessManager::ControlledProcessManager(string processManagerName, const essentials::AgentID* processManagerId, QBoxLayout* parentLayout)
     : name(processManagerName)
     , id(processManagerId)
-    , pmRegistry( essentials::RobotExecutableRegistry::get())
+    , pmRegistry(essentials::RobotExecutableRegistry::get())
     , parentLayout(parentLayout)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    this->msgTimeOut = duration<double>((*sc)["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    this->msgTimeOut = duration<double>(sc["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
 }
 
 ControlledProcessManager::~ControlledProcessManager()

--- a/pm_control/src/pm_widget/ControlledRobot.cpp
+++ b/pm_control/src/pm_widget/ControlledRobot.cpp
@@ -5,11 +5,11 @@
 #include "ui_RobotProcessesWidget.h"
 
 #include <SystemConfig.h>
+#include <essentials/AgentID.h>
+#include <essentials/BroadcastID.h>
 #include <process_manager/ExecutableMetaData.h>
 #include <process_manager/ProcessCommand.h>
 #include <process_manager/RobotExecutableRegistry.h>
-#include <essentials/AgentID.h>
-#include <essentials/BroadcastID.h>
 
 #include <limits.h>
 #include <ros/ros.h>
@@ -24,7 +24,7 @@ ControlledRobot::ControlledRobot(string robotName, const essentials::AgentID* ro
 {
     // setup gui stuff
     this->_robotProcessesWidget->setupUi(this->robotProcessesQFrame);
-    auto pmRegistry =  essentials::RobotExecutableRegistry::get();
+    auto pmRegistry = essentials::RobotExecutableRegistry::get();
     if (dynamic_cast<const essentials::BroadcastID*>(parentPMid)) {
         // don't show in robot_control
         this->_robotProcessesWidget->robotHostLabel->hide();
@@ -47,18 +47,18 @@ ControlledRobot::ControlledRobot(string robotName, const essentials::AgentID* ro
     }
 
     // construct all known executables
-    const vector< essentials::ExecutableMetaData*>& execMetaDatas = pmRegistry->getExecutables();
+    const vector<essentials::ExecutableMetaData*>& execMetaDatas = pmRegistry->getExecutables();
     ControlledExecutable* controlledExec;
     for (auto execMetaDataEntry : execMetaDatas) {
         controlledExec = new ControlledExecutable(execMetaDataEntry, this);
         this->controlledExecMap.emplace(execMetaDataEntry->id, controlledExec);
     }
 
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    this->msgTimeOut = chrono::duration<double>((*sc)["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    this->msgTimeOut = chrono::duration<double>(sc["ProcessManaging"]->get<unsigned long>("PMControl.timeLastMsgReceivedTimeOut", NULL));
 
     ros::NodeHandle* nh = new ros::NodeHandle();
-    string cmdTopic = (*essentials::SystemConfig::getInstance())["ProcessManaging"]->get<string>("Topics.processCmdTopic", NULL);
+    string cmdTopic = sc["ProcessManaging"]->get<string>("Topics.processCmdTopic", NULL);
     processCommandPub = nh->advertise<process_manager::ProcessCommand>(cmdTopic, 10);
 }
 

--- a/process_manager/include/process_manager/ProcessManager.h
+++ b/process_manager/include/process_manager/ProcessManager.h
@@ -1,23 +1,25 @@
 #pragma once
 
-#define PM_DEBUG  // for toggling debug output
+#define PM_DEBUG // for toggling debug output
 
 #include "process_manager/ProcessCommand.h"
 #include "process_manager/ProcessStat.h"
 #include "process_manager/ProcessStats.h"
 
+#include <SystemConfig.h>
 #include <essentials/AgentID.h>
 #include <essentials/AgentIDFactory.h>
-#include <SystemConfig.h>
 
-#include <ros/ros.h>
 #include <chrono>
+#include <ros/ros.h>
 
-namespace std {
+namespace std
+{
 class thread;
 }
 
-namespace  essentials {
+namespace essentials
+{
 
 class ManagedRobot;
 class ManagedExecutable;
@@ -25,8 +27,9 @@ class RobotMetaData;
 class ExecutableMetaData;
 class RobotExecutableRegistry;
 
-class ProcessManager {
-public:
+class ProcessManager
+{
+  public:
     ProcessManager(int argc, char** argv);
     virtual ~ProcessManager();
     void start();
@@ -43,9 +46,7 @@ public:
     static int numCPUs;  /* < including hyper threading cores */
     static bool running; /* < has to be static, to be changeable within ProcessManager::pmSignintHandler() */
 
-private:
-    essentials::SystemConfig* sc;
-    std::string ownHostname;
+  private:
     const essentials::AgentID* ownId;
     bool simMode;
     std::map<const essentials::AgentID*, ManagedRobot*, essentials::AgentIDComparator> robotMap;
@@ -75,4 +76,4 @@ private:
     void report();
 };
 
-}  // namespace  essentials
+} // namespace  essentials

--- a/process_manager/include/process_manager/RobotExecutableRegistry.h
+++ b/process_manager/include/process_manager/RobotExecutableRegistry.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <SystemConfig.h>
 #include <essentials/AgentID.h>
 #include <essentials/AgentIDFactory.h>
 #include <essentials/AgentIDManager.h>
-#include <SystemConfig.h>
 
 #include <map>
 #include <stdint.h>
@@ -56,7 +56,6 @@ class RobotExecutableRegistry
     std::vector<ExecutableMetaData*> executableList;
     std::vector<std::string> interpreter;
     std::map<std::string, std::vector<std::pair<int, int>>> bundlesMap;
-    essentials::SystemConfig* sc;
     essentials::AgentIDManager* agentIDManager;
 };
 

--- a/process_manager/src/ProcessManager.cpp
+++ b/process_manager/src/ProcessManager.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 #include <unistd.h>
 
-namespace  essentials
+namespace essentials
 {
 
 using std::cerr;
@@ -50,26 +50,25 @@ ProcessManager::ProcessManager(int argc, char** argv)
     , simMode(false)
     , ownId(nullptr)
 {
-    this->sc = essentials::SystemConfig::getInstance();
-    this->ownHostname = this->sc->getHostname();
-    this->pmRegistry =  essentials::RobotExecutableRegistry::get();
-
+    this->pmRegistry = essentials::RobotExecutableRegistry::get();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    const std::string ownHostname = sc.getHostname();
     /* Initialise some data structures for better performance in searchProcFS-Method with
      * data from Globals.conf and Processes.conf file. */
 
     // Register robots from Globals.conf
     const essentials::AgentID* tmpAgentID;
-    auto robotNames = (*this->sc)["Globals"]->getSections("Globals.Team", NULL);
+    auto robotNames = sc["Globals"]->getSections("Globals.Team", NULL);
     for (auto robotName : (*robotNames)) {
         tmpAgentID = this->pmRegistry->addRobot(robotName);
-        if (robotName == this->ownHostname) {
+        if (robotName == ownHostname) {
             this->ownId = tmpAgentID;
         }
     }
 
     // Register local hostname, if it does not exist in Globals.conf
     if (this->ownId == nullptr) {
-        this->ownId = this->pmRegistry->addRobot(this->ownHostname);
+        this->ownId = this->pmRegistry->addRobot(ownHostname);
     }
 
     // autostart for robots
@@ -85,12 +84,12 @@ ProcessManager::ProcessManager(int argc, char** argv)
 
     if (autostart) {
         // Create ManagedRobot-Object for local system/robot
-        this->robotMap.emplace(ownId, new ManagedRobot(this->ownHostname, ownId, this));
+        this->robotMap.emplace(ownId, new ManagedRobot(ownHostname, ownId, this));
     }
 
     // Register executables from Processes.conf
     int tmpExecID = -1;
-    auto processDescriptions = (*this->sc)["ProcessManaging"]->getSections("Processes.ProcessDescriptions", NULL);
+    auto processDescriptions = sc["ProcessManaging"]->getSections("Processes.ProcessDescriptions", NULL);
     for (auto processSectionName : (*processDescriptions)) {
         tmpExecID = this->pmRegistry->addExecutable(processSectionName);
         // This autostart functionality is for easier testing. The local robot starts the processes automatically
@@ -99,7 +98,7 @@ ProcessManager::ProcessManager(int argc, char** argv)
         }
     }
 
-    this->interpreters = (*this->sc)["ProcessManaging"]->getList<string>("Processes.Interpreter", NULL);
+    this->interpreters = sc["ProcessManaging"]->getList<string>("Processes.Interpreter", NULL);
     cout << "PM: Number of Interpreters: " << this->interpreters.size() << endl;
     this->pmRegistry->setInterpreters(interpreters);
 
@@ -229,9 +228,9 @@ void ProcessManager::initCommunication(int argc, char** argv)
     ros::init(argc, argv, "ProcessManager");
     rosNode = new ros::NodeHandle();
     spinner = new ros::AsyncSpinner(4);
-
-    this->processCmdTopic = (*sc)["ProcessManaging"]->get<string>("Topics.processCmdTopic", NULL);
-    this->processStatsTopic = (*sc)["ProcessManaging"]->get<string>("Topics.processStatsTopic", NULL);
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    this->processCmdTopic = sc["ProcessManaging"]->get<string>("Topics.processCmdTopic", NULL);
+    this->processStatsTopic = sc["ProcessManaging"]->get<string>("Topics.processStatsTopic", NULL);
 
     processCommandSub = rosNode->subscribe(this->processCmdTopic, 10, &ProcessManager::handleProcessCommand, (ProcessManager*)this);
     processStatePub = rosNode->advertise<process_manager::ProcessStats>(this->processStatsTopic, 10);
@@ -435,7 +434,7 @@ string ProcessManager::getRobotEnvironmentVariable(string processId)
     }
 
     ifs.close();
-    return this->ownHostname;
+    return essentials::SystemConfig::getInstance().getHostname();
 }
 
 /**
@@ -570,18 +569,19 @@ bool ProcessManager::selfCheck()
             // remember started roscore in process managing data structures
             int roscoreExecId;
             if (this->pmRegistry->getExecutableIdByExecName(roscoreExecName, roscoreExecId)) {
-                const essentials::AgentID* agentID = this->pmRegistry->getRobotId(this->ownHostname);
+                const std::string ownHostName = essentials::SystemConfig::getInstance().getHostname();
+                const essentials::AgentID* agentID = this->pmRegistry->getRobotId(ownHostName);
                 if (agentID != nullptr) {
                     // create managed robot if necessary and change desired state of roscore accordingly
                     auto mngdRobot = this->robotMap.find(agentID);
                     if (mngdRobot != this->robotMap.end()) {
                         mngdRobot->second->changeDesiredState(roscoreExecId, true, this->pmRegistry);
                     } else {
-                        auto emplaceResult = this->robotMap.emplace(agentID, new ManagedRobot(this->ownHostname, agentID, this));
+                        auto emplaceResult = this->robotMap.emplace(agentID, new ManagedRobot(ownHostName, agentID, this));
                         emplaceResult.first->second->changeDesiredState(roscoreExecId, true, this->pmRegistry);
                     }
                 } else {
-                    cerr << "PM: The robot " << this->ownHostname << " is unknown!" << endl;
+                    cerr << "PM: The robot " << ownHostName << " is unknown!" << endl;
                 }
             } else {
                 cerr << "PM: The ID of the roscore executable is unknown!" << endl;
@@ -677,13 +677,13 @@ void ProcessManager::pmSigchildHandler(int sig)
 int main(int argc, char** argv)
 {
     // Set kernel page size for human readable memory consumption
-     essentials::ManagedExecutable::kernelPageSize = sysconf(_SC_PAGESIZE);
+    essentials::ManagedExecutable::kernelPageSize = sysconf(_SC_PAGESIZE);
     // Determine number of cores
-    while (essentials::FileSystem::pathExists("/sys/devices/system/cpu/cpu" + std::to_string( essentials::ProcessManager::numCPUs))) {
-         essentials::ProcessManager::numCPUs++;
+    while (essentials::FileSystem::pathExists("/sys/devices/system/cpu/cpu" + std::to_string(essentials::ProcessManager::numCPUs))) {
+        essentials::ProcessManager::numCPUs++;
     }
 
-     essentials::ProcessManager* pm = new  essentials::ProcessManager(argc, argv);
+    essentials::ProcessManager* pm = new essentials::ProcessManager(argc, argv);
     if (pm->selfCheck()) {
         try {
             pm->initCommunication(argc, argv);
@@ -692,9 +692,9 @@ int main(int argc, char** argv)
             return -1;
         }
         // has to be set after ProcessManager::initCommunication() , in order to override the ROS signal handler
-        signal(SIGINT,  essentials::ProcessManager::pmSigintHandler);
+        signal(SIGINT, essentials::ProcessManager::pmSigintHandler);
 
-        signal(SIGCHLD,  essentials::ProcessManager::pmSigchildHandler);
+        signal(SIGCHLD, essentials::ProcessManager::pmSigchildHandler);
 
         pm->start();
 

--- a/process_manager/src/RobotExecutableRegistry.cpp
+++ b/process_manager/src/RobotExecutableRegistry.cpp
@@ -22,7 +22,7 @@ using std::string;
 using std::stringstream;
 using std::vector;
 
-namespace  essentials
+namespace essentials
 {
 
 RobotExecutableRegistry* RobotExecutableRegistry::get()
@@ -32,8 +32,7 @@ RobotExecutableRegistry* RobotExecutableRegistry::get()
 }
 
 RobotExecutableRegistry::RobotExecutableRegistry()
-    : sc(essentials::SystemConfig::getInstance())
-    , agentIDManager(new essentials::AgentIDManager(new essentials::AgentIDFactory()))
+    : agentIDManager(new essentials::AgentIDManager(new essentials::AgentIDFactory()))
 {
 }
 
@@ -53,12 +52,12 @@ RobotExecutableRegistry::~RobotExecutableRegistry()
 const map<string, vector<pair<int, int>>>* const RobotExecutableRegistry::getBundlesMap()
 {
     if (bundlesMap.size() == 0) {
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
         // Read bundles from Processes.conf
-        auto bundlesSections = (*this->sc)["ProcessManaging"]->getSections("Processes.Bundles", NULL);
+        auto bundlesSections = sc["ProcessManaging"]->getSections("Processes.Bundles", NULL);
         for (auto bundleName : (*bundlesSections)) {
-            vector<int> processList = (*this->sc)["ProcessManaging"]->getList<int>("Processes.Bundles", bundleName.c_str(), "processList", NULL);
-            vector<string> processParamsList =
-                (*this->sc)["ProcessManaging"]->getList<string>("Processes.Bundles", bundleName.c_str(), "processParamsList", NULL);
+            vector<int> processList = sc["ProcessManaging"]->getList<int>("Processes.Bundles", bundleName.c_str(), "processList", NULL);
+            vector<string> processParamsList = sc["ProcessManaging"]->getList<string>("Processes.Bundles", bundleName.c_str(), "processParamsList", NULL);
             if (processList.size() != processParamsList.size()) {
                 cerr << "RobotExecutableReg: Number of processes does not match the number of parameter sets for the "
                         "bundle '"
@@ -171,7 +170,8 @@ const essentials::AgentID* RobotExecutableRegistry::addRobot(string agentName)
     const essentials::AgentID* agentID;
 
     try {
-        int tmpID = (*sc)["Globals"]->get<int>("Globals.Team", agentName.c_str(), "ID", NULL);
+        essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+        int tmpID = sc["Globals"]->get<int>("Globals.Team", agentName.c_str(), "ID", NULL);
         std::vector<uint8_t> agentIDVector;
         for (int i = 0; i < sizeof(int); i++) {
             agentIDVector.push_back(*(((uint8_t*)&tmpID) + i));
@@ -267,7 +267,6 @@ int RobotExecutableRegistry::addExecutable(string execSectionName)
         return -1;
     }
 
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
     int execId;
     string processMode;
     string execName;
@@ -275,12 +274,13 @@ int RobotExecutableRegistry::addExecutable(string execSectionName)
     string rosPackage = "NOT-FOUND"; // optional
     string prefixCmd = "NOT-FOUND";  // optional
 
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     try {
-        execId = (*sc)["ProcessManaging"]->get<int>("Processes.ProcessDescriptions", execSectionName.c_str(), "id", NULL);
-        processMode = (*sc)["ProcessManaging"]->get<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "mode", NULL);
-        execName = (*sc)["ProcessManaging"]->get<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "execName", NULL);
-        rosPackage = (*sc)["ProcessManaging"]->tryGet<string>("NOT-FOUND", "Processes.ProcessDescriptions", execSectionName.c_str(), "rosPackage", NULL);
-        prefixCmd = (*sc)["ProcessManaging"]->tryGet<string>("NOT-FOUND", "Processes.ProcessDescriptions", execSectionName.c_str(), "prefixCmd", NULL);
+        execId = sc["ProcessManaging"]->get<int>("Processes.ProcessDescriptions", execSectionName.c_str(), "id", NULL);
+        processMode = sc["ProcessManaging"]->get<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "mode", NULL);
+        execName = sc["ProcessManaging"]->get<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "execName", NULL);
+        rosPackage = sc["ProcessManaging"]->tryGet<string>("NOT-FOUND", "Processes.ProcessDescriptions", execSectionName.c_str(), "rosPackage", NULL);
+        prefixCmd = sc["ProcessManaging"]->tryGet<string>("NOT-FOUND", "Processes.ProcessDescriptions", execSectionName.c_str(), "prefixCmd", NULL);
     } catch (runtime_error& e) {
         cerr << "PM-Registry: Cannot add executable '" << execSectionName << "', because of faulty values in ProcessManaging.conf!" << endl;
         return -1;
@@ -298,13 +298,13 @@ int RobotExecutableRegistry::addExecutable(string execSectionName)
     }
 
     ExecutableMetaData* execMetaData = new ExecutableMetaData(execSectionName, execId, processMode, execName, rosPackage, prefixCmd, absExecName);
-    auto paramSets = (*sc)["ProcessManaging"]->tryGetNames("NONE", "Processes.ProcessDescriptions", execSectionName.c_str(), "paramSets", NULL);
+    auto paramSets = sc["ProcessManaging"]->tryGetNames("NONE", "Processes.ProcessDescriptions", execSectionName.c_str(), "paramSets", NULL);
     if (paramSets->size() > 1 || paramSets->at(0) != "NONE") {
         for (string paramSetKeyString : (*paramSets)) {
             try {
                 int paramSetKey = stoi(paramSetKeyString);
-                auto paramSetValues = (*sc)["ProcessManaging"]->getList<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "paramSets",
-                                                                                paramSetKeyString.c_str(), NULL);
+                auto paramSetValues = sc["ProcessManaging"]->getList<string>("Processes.ProcessDescriptions", execSectionName.c_str(), "paramSets",
+                                                                             paramSetKeyString.c_str(), NULL);
 
                 // first param is always the executable name
                 vector<char*> currentParams;

--- a/system_config/include/SystemConfig.h
+++ b/system_config/include/SystemConfig.h
@@ -22,23 +22,23 @@ class SystemConfig
 {
 
   protected:
-    static std::string rootPath;
-    static std::string logPath;
-    static std::string configPath;
-    static std::string hostname;
-    static std::mutex configsMapMutex;
-    static std::map<std::string, std::shared_ptr<Configuration>> configs;
-    static const char NODE_NAME_SEPERATOR = '_';
+    std::string rootPath;
+    std::string logPath;
+    std::string configPath;
+    std::string hostname;
+    std::mutex configsMapMutex;
+    std::map<std::string, std::shared_ptr<Configuration>> configs;
+    const char NODE_NAME_SEPERATOR = '_';
 
   public:
-    static SystemConfig* getInstance();
-    static void shutdown();
-    static std::string robotNodeName(const std::string& nodeName);
-    static int getOwnRobotID();
-    static int getRobotID(const std::string& name);
-    static std::string getHostname();
-    static void setHostname(const std::string& newHostname);
-    static void resetHostname();
+    static SystemConfig& getInstance();
+    void shutdown();
+    std::string robotNodeName(const std::string& nodeName);
+    int getOwnRobotID();
+    int getRobotID(const std::string& name);
+    std::string getHostname();
+    void setHostname(const std::string& newHostname);
+    void resetHostname();
 
     Configuration* operator[](const std::string& s);
     std::string getRootPath();
@@ -46,7 +46,7 @@ class SystemConfig
     std::string getLogPath();
     void setRootPath(std::string rootPath);
     void setConfigPath(std::string configPath);
-    static std::string getEnv(const std::string& var);
+    std::string getEnv(const std::string& var);
 
   private:
     SystemConfig();

--- a/system_config/src/SystemConfig.cpp
+++ b/system_config/src/SystemConfig.cpp
@@ -14,22 +14,14 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
-// Initialize static variables
-std::string SystemConfig::rootPath;
-std::string SystemConfig::logPath;
-std::string SystemConfig::configPath;
-std::string SystemConfig::hostname;
-std::mutex SystemConfig::configsMapMutex;
-std::map<std::string, std::shared_ptr<Configuration>> SystemConfig::configs;
-
 /**
  * The method for getting the singleton instance.
  * @return A pointer to the SystemConfig object, you must not delete.
  */
-SystemConfig* SystemConfig::getInstance()
+SystemConfig& SystemConfig::getInstance()
 {
     static SystemConfig instance;
-    return &instance;
+    return instance;
 }
 
 /**
@@ -157,7 +149,7 @@ int SystemConfig::getOwnRobotID()
 int SystemConfig::getRobotID(const string& name)
 {
     // TODO this should be optional for dynamic teams (is it ok to return ints?)
-    Configuration* tmp = (*SystemConfig::getInstance())["Globals"];
+    Configuration* tmp = (SystemConfig::getInstance())["Globals"];
     int ownRobotID = tmp->get<int>("Globals", "Team", name.c_str(), "ID", NULL);
     return ownRobotID;
 }

--- a/system_config/test/test_system_config.cpp
+++ b/system_config/test/test_system_config.cpp
@@ -9,47 +9,47 @@
 TEST(SystemConfigBasics, readValues)
 {
     // bring up the SystemConfig with the corresponding path
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
-    sc->setRootPath(".");
-    sc->setConfigPath("./etc");
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
+    sc.setRootPath(".");
+    sc.setConfigPath("./etc");
 
     // read int
-    unsigned short uShortTestValue = (*sc)["Test"]->get<unsigned short>("uShortTestValue", NULL);
+    unsigned short uShortTestValue = sc["Test"]->get<unsigned short>("uShortTestValue", NULL);
     EXPECT_EQ(3, uShortTestValue);
 
     // read int
-    int intTestValue = (*sc)["Test"]->get<int>("intTestValue", NULL);
+    int intTestValue = sc["Test"]->get<int>("intTestValue", NULL);
     EXPECT_EQ(221, intTestValue);
 
     // read double
-    double doubleTestValue = (*sc)["Test"]->get<double>("doubleTestValue", NULL);
+    double doubleTestValue = sc["Test"]->get<double>("doubleTestValue", NULL);
     EXPECT_DOUBLE_EQ(0.66234023823, doubleTestValue);
 
     // read float
-    float floatTestValue = (*sc)["Test"]->get<float>("floatTestValue", NULL);
+    float floatTestValue = sc["Test"]->get<float>("floatTestValue", NULL);
     EXPECT_FLOAT_EQ(1.14f, floatTestValue);
 
     // read spaceTestValue
-    int spaceTestValue = (*sc)["Test"]->get<int>("spaceTestValue", NULL);
+    int spaceTestValue = sc["Test"]->get<int>("spaceTestValue", NULL);
     EXPECT_FLOAT_EQ(6, spaceTestValue);
 
     // read list of strings
-    std::vector<std::string> stringListTestValue = (*sc)["Test"]->getList<std::string>("stringListTestValue", NULL);
+    std::vector<std::string> stringListTestValue = sc["Test"]->getList<std::string>("stringListTestValue", NULL);
     std::vector<std::string> referenceStringList{"asdf", "bla", "blub", "hust hust", "möp"};
     for (int i = 0; i < stringListTestValue.size(); i++) {
         EXPECT_STREQ(stringListTestValue[i].c_str(), referenceStringList[i].c_str());
     }
 
     // read TestSectionValue1
-    std::string testSectionValue1 = (*sc)["Test"]->get<std::string>("TestSection.TestSectionValue1", NULL);
+    std::string testSectionValue1 = sc["Test"]->get<std::string>("TestSection.TestSectionValue1", NULL);
     EXPECT_STREQ("TestSectionValue1", testSectionValue1.c_str());
 
     // read TestSectionValue1 with two conf-path parameters
-    std::string testSectionValue11 = (*sc)["Test"]->get<std::string>("TestSection", "TestSectionValue1", NULL);
+    std::string testSectionValue11 = sc["Test"]->get<std::string>("TestSection", "TestSectionValue1", NULL);
     EXPECT_STREQ("TestSectionValue1", testSectionValue11.c_str());
 
     // read TestSectionValue2
-    float testSectionValue2 = (*sc)["Test"]->get<float>("TestSection.TestSectionValue2", NULL);
+    float testSectionValue2 = sc["Test"]->get<float>("TestSection.TestSectionValue2", NULL);
     EXPECT_FLOAT_EQ(0.66412f, testSectionValue2);
 }
 // Run all the tests that were declared with TEST()

--- a/system_util/src/Logging.cpp
+++ b/system_util/src/Logging.cpp
@@ -20,13 +20,13 @@ namespace logging
  */
 std::string getLogFilename(const std::string& file)
 {
-    essentials::SystemConfig* sc = essentials::SystemConfig::getInstance();
+    essentials::SystemConfig& sc = essentials::SystemConfig::getInstance();
     auto time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     char mbstr[100];
     // strcpy(mbstr, "CheckManagedExecutable_CPP"); // what was this for???
     std::strftime(mbstr, 100, "%Y-%0m-%0d_%0H-%0M-%0S", localtime(&time));
     std::string logFileName = std::string(mbstr) + "_" + file + ".txt";
-    return essentials::FileSystem::combinePaths(sc->getLogPath(), logFileName);
+    return essentials::FileSystem::combinePaths(sc.getLogPath(), logFileName);
 }
 
 /**


### PR DESCRIPTION
1) SystemConfig::getInstance() now returns reference.
2) Removed caching singleton SystemConfig instance as private members.