### PR TITLE
Modify AgentId to be independently usable by alica applications

### DIFF
--- a/agent_id/include/essentials/AgentID.h
+++ b/agent_id/include/essentials/AgentID.h
@@ -10,12 +10,20 @@ class AgentID
     friend struct std::hash<essentials::AgentID>;
 
   public:
+    AgentID()
+        : _type(UUID_TYPE)
+    {
+    }
+    AgentID(const std::vector<uint8_t>& bytes);
     AgentID(const uint8_t* idBytes, int idSize, uint8_t type = UUID_TYPE);
     virtual ~AgentID();
     virtual bool operator==(const AgentID& obj) const;
     virtual bool operator!=(const AgentID& obj) const;
     virtual bool operator<(const AgentID& other) const;
     virtual bool operator>(const AgentID& other) const;
+    void operator=(const std::vector<uint8_t>& other_id);
+    operator bool() const { return !_id.empty(); }
+
     virtual const uint8_t* getRaw() const;
     virtual int getSize() const;
     virtual std::vector<uint8_t> toByteVector() const;
@@ -24,36 +32,35 @@ class AgentID
 
     friend std::ostream& operator<<(std::ostream& os, const essentials::AgentID& obj)
     {
-        if (obj.id.size() <= sizeof(int)) {
+        if (obj._id.size() <= sizeof(int)) {
             std::vector<uint8_t> tmpLong;
-            for (int i = 0; i < static_cast<int>(obj.id.size()); i++) {
-                tmpLong.push_back(obj.id[i]);
+            for (int i = 0; i < static_cast<int>(obj._id.size()); i++) {
+                tmpLong.push_back(obj._id[i]);
             }
-            for (int i = 0; i < static_cast<int>(sizeof(int) - obj.id.size()); i++) {
+            for (int i = 0; i < static_cast<int>(sizeof(int) - obj._id.size()); i++) {
                 tmpLong.push_back(0);
             }
             os << (int)(*tmpLong.data());
         } else {
             std::vector<uint8_t> tmpShort;
-            tmpShort.push_back(obj.id[0]);
-            tmpShort.push_back(obj.id[1]);
+            tmpShort.push_back(obj._id[0]);
+            tmpShort.push_back(obj._id[1]);
             os << (short)(*tmpShort.data()) << "[...]";
             tmpShort.clear();
-            tmpShort.push_back(obj.id[obj.id.size() - 2]);
-            tmpShort.push_back(obj.id[obj.id.size() - 1]);
+            tmpShort.push_back(obj._id[obj._id.size() - 2]);
+            tmpShort.push_back(obj._id[obj._id.size() - 1]);
             os << (short)(*tmpShort.data());
         }
         return os;
     }
-
-    const uint8_t TYPE;
 
     static const uint8_t INT_TYPE = 0;
     static const uint8_t BC_TYPE = 1;
     static const uint8_t UUID_TYPE = 2;
 
   private:
-    std::vector<uint8_t> id;
+    std::vector<uint8_t> _id;
+    uint8_t _type;
 };
 
 struct AgentIDComparator

--- a/agent_id/include/essentials/AgentID.h
+++ b/agent_id/include/essentials/AgentID.h
@@ -77,5 +77,13 @@ struct AgentIDHash
 {
     std::size_t operator()(const AgentID* const obj) const { return obj->hash(); }
 };
-
 } /* namespace essentials */
+
+namespace std
+{
+template <>
+struct hash<essentials::AgentID>
+{
+    std::size_t operator()(const essentials::AgentID id) const noexcept { return id.hash(); }
+};
+}

--- a/agent_id/src/AgentID.cpp
+++ b/agent_id/src/AgentID.cpp
@@ -1,46 +1,58 @@
 #include "essentials/AgentID.h"
 
-namespace essentials {
+namespace essentials
+{
+
+AgentID::AgentID(const std::vector<uint8_t>& bytes)
+    : _type(UUID_TYPE)
+    , _id(bytes)
+{
+}
 
 AgentID::AgentID(const uint8_t* idBytes, int idSize, uint8_t type)
-        : TYPE(type) {
+    : _type(type)
+{
     for (int i = 0; i < idSize; i++) {
-        this->id.push_back(idBytes[i]);
+        _id.push_back(idBytes[i]);
     }
 }
 
 AgentID::~AgentID(){};
 
-uint8_t AgentID::getType() const {
-    return this->TYPE;
+uint8_t AgentID::getType() const
+{
+    return _type;
 }
 
-bool AgentID::operator==(const AgentID& other) const {
-    if (this->id.size() != other.id.size()) {
+bool AgentID::operator==(const AgentID& other) const
+{
+    if (_id.size() != other._id.size()) {
         return false;
     }
-    for (int i = 0; i < static_cast<int>(this->id.size()); i++) {
-        if (this->id[i] != other.id[i]) {
+    for (int i = 0; i < static_cast<int>(_id.size()); i++) {
+        if (_id[i] != other._id[i]) {
             return false;
         }
     }
     return true;
 }
 
-bool AgentID::operator!=(const AgentID& other) const {
+bool AgentID::operator!=(const AgentID& other) const
+{
     return !(*this == other);
 }
 
-bool AgentID::operator<(const AgentID& other) const {
-    if (this->id.size() < other.id.size()) {
+bool AgentID::operator<(const AgentID& other) const
+{
+    if (_id.size() < other._id.size()) {
         return true;
-    } else if (this->id.size() > other.id.size()) {
+    } else if (_id.size() > other._id.size()) {
         return false;
     }
-    for (int i = 0; i < this->id.size(); i++) {
-        if (this->id[i] < other.id[i]) {
+    for (int i = 0; i < _id.size(); i++) {
+        if (_id[i] < other._id[i]) {
             return true;
-        } else if (this->id[i] > other.id[i]) {
+        } else if (_id[i] > other._id[i]) {
             return false;
         }
         // else continue, because both bytes where equal and the next byte needs to be considered
@@ -48,16 +60,17 @@ bool AgentID::operator<(const AgentID& other) const {
     return false;
 }
 
-bool AgentID::operator>(const AgentID& other) const {
-    if (this->id.size() > other.id.size()) {
+bool AgentID::operator>(const AgentID& other) const
+{
+    if (_id.size() > other._id.size()) {
         return true;
-    } else if (this->id.size() < other.id.size()) {
+    } else if (_id.size() < other._id.size()) {
         return false;
     }
-    for (int i = 0; i < this->id.size(); i++) {
-        if (this->id[i] > other.id[i]) {
+    for (int i = 0; i < _id.size(); i++) {
+        if (_id[i] > other._id[i]) {
             return true;
-        } else if (this->id[i] < other.id[i]) {
+        } else if (_id[i] < other._id[i]) {
             return false;
         }
         // else continue, because both bytes where equal and the next byte needs to be considered
@@ -65,16 +78,25 @@ bool AgentID::operator>(const AgentID& other) const {
     return false;
 }
 
-const uint8_t* AgentID::getRaw() const {
-    return this->id.data();
+void AgentID::operator=(const std::vector<uint8_t>& other_id)
+{
+    _id = other_id;
+    _type = UUID_TYPE;
 }
 
-int AgentID::getSize() const {
-    return this->id.size();
+const uint8_t* AgentID::getRaw() const
+{
+    return _id.data();
 }
 
-std::vector<uint8_t> AgentID::toByteVector() const {
-    return this->id;
+int AgentID::getSize() const
+{
+    return _id.size();
+}
+
+std::vector<uint8_t> AgentID::toByteVector() const
+{
+    return _id;
 }
 
 /**
@@ -82,13 +104,14 @@ std::vector<uint8_t> AgentID::toByteVector() const {
  * https://en.wikipedia.org/wiki/MurmurHash
  * https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
  */
-std::size_t AgentID::hash() const {
-    const uint8_t* key = this->id.data();
-    int len = this->id.size();
+std::size_t AgentID::hash() const
+{
+    const uint8_t* key = _id.data();
+    int len = _id.size();
     uint32_t h = 13;
     if (len > 3) {
-        const uint32_t* key_x4 = (const uint32_t*) key;
-        size_t i = this->id.size() >> 2;
+        const uint32_t* key_x4 = (const uint32_t*)key;
+        size_t i = _id.size() >> 2;
         do {
             uint32_t k = *key_x4++;
             k *= 0xcc9e2d51;
@@ -98,7 +121,7 @@ std::size_t AgentID::hash() const {
             h = (h << 13) | (h >> 19);
             h = (h * 5) + 0xe6546b64;
         } while (--i);
-        key = (const uint8_t*) key_x4;
+        key = (const uint8_t*)key_x4;
     }
     if (len & 3) {
         size_t i = len & 3;


### PR DESCRIPTION
AgentIDConstptr has a dependency on Agentidmanager which is no longer exposed by new AlicaContext api