### PR TITLE
"Fix" for stack smash in case of huge Ids.

### DIFF
--- a/agent_id/include/essentials/AgentID.h
+++ b/agent_id/include/essentials/AgentID.h
@@ -24,6 +24,12 @@ class AgentID
     virtual bool operator>(const AgentID& other) const;
     void operator=(const std::vector<uint8_t>& other_id);
     operator bool() const { return !_id.empty(); }
+
+    /**
+     * Tries to convert this ID into an uint64_t.
+     * @throws Exception if ID.size() > sizeof(uint64_t)!
+     * @return uint64_t representation of the bytes in this ID.
+     */
     operator uint64_t() const;
 
     virtual const uint8_t* getRaw() const;

--- a/agent_id/src/test/AgentIDTests.cpp
+++ b/agent_id/src/test/AgentIDTests.cpp
@@ -31,6 +31,31 @@ TEST(AgentID, ConstructionOfHugeID) {
     delete id1;
 }
 
+TEST(AgentID, ConstructionOfHugeStringBasedID) {
+
+    essentials::AgentID* id1;
+    std::string agent_id_param = "instjqndaczdtsshocazkdtgpxknutnrkc79bbd8f95j4wv4";
+    id1 = new essentials::AgentID(std::vector<uint8_t>(agent_id_param.begin(), agent_id_param.end()));
+    EXPECT_EQ(id1->getSize(), agent_id_param.size()) << "Maybe one character did take more than one byte?!";
+    delete id1;
+}
+
+TEST(AgentID, ConversionOfHugeIDtoUInt64_T) {
+    essentials::AgentID* id1;
+    std::string agent_id_param = "instjqndaczdtsshocazkdtgpxknutnrkc79bbd8f95j4wv4";
+    id1 = new essentials::AgentID(std::vector<uint8_t>(agent_id_param.begin(), agent_id_param.end()));
+    bool caughtException = false;
+    try {
+        uint64_t intRepresentation = *id1;
+        std::cout << intRepresentation << std::endl;
+    } catch (std::string& errorString) {
+//        std::cout << errorString << std::endl;
+        caughtException = true;
+    }
+    EXPECT_TRUE(caughtException) << "Conversion of huge ID to uint64_t did not raise an exception!";
+    delete id1;
+}
+
 TEST(AgentID, ToByteVectorReturnsCopy) {
     std::vector<uint8_t> bytes1;
     int size = 100;

--- a/agent_id/src/test/AgentIDTests.cpp
+++ b/agent_id/src/test/AgentIDTests.cpp
@@ -34,7 +34,7 @@ TEST(AgentID, ConstructionOfHugeID) {
 TEST(AgentID, ConstructionOfHugeStringBasedID) {
 
     essentials::AgentID* id1;
-    std::string agent_id_param = "instjqndaczdtsshocazkdtgpxknutnrkc79bbd8f95j4wv4";
+    const std::string agent_id_param = "instjqndaczdtsshocazkdtgpxknutnrkc79bbd8f95j4wv4";
     id1 = new essentials::AgentID(std::vector<uint8_t>(agent_id_param.begin(), agent_id_param.end()));
     EXPECT_EQ(id1->getSize(), agent_id_param.size()) << "Maybe one character did take more than one byte?!";
     delete id1;


### PR DESCRIPTION
- added two tests for conversion to uint64_t
- throw proper exception for conversion of ids that are longer than uint64_t

